### PR TITLE
ci(ghpkgs): fix plugin resolution by preinstalling SR plugins

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -44,8 +44,19 @@ jobs:
         working-directory: mcp/codex-mcp-server
         run: npm run build
 
+      - name: Install semantic-release + plugins (no-save)
+        run: |
+          npm i --no-save \
+            semantic-release \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            @semantic-release/changelog \
+            @semantic-release/npm \
+            @semantic-release/git \
+            @semantic-release/github
+
       - name: Semantic Release (publish to GH Packages)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx -y --registry=https://registry.npmjs.org/ semantic-release
+        run: npx semantic-release


### PR DESCRIPTION
在 CI 中使用 npm --no-save 预安装 semantic-release 及其插件，修复 @semantic-release/changelog 模块解析失败。
合并后再次触发 Release to GH Packages，应能正常执行（无语义化提交将 no release）。