### PR TITLE
ci(ghpkgs): switch to exec publish; npm plugin only versions

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -52,6 +52,7 @@ jobs:
             @semantic-release/release-notes-generator \
             @semantic-release/changelog \
             @semantic-release/npm \
+            @semantic-release/exec \
             @semantic-release/git \
             @semantic-release/github
 

--- a/.releaserc
+++ b/.releaserc
@@ -10,7 +10,13 @@
     ],
     [
       "@semantic-release/npm",
-      { "pkgRoot": "mcp/codex-mcp-server", "npmPublish": true }
+      { "pkgRoot": "mcp/codex-mcp-server", "npmPublish": false }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "cd mcp/codex-mcp-server && npm publish --registry https://npm.pkg.github.com"
+      }
     ],
     [
       "@semantic-release/git",
@@ -25,4 +31,3 @@
     "@semantic-release/github"
   ]
 }
-


### PR DESCRIPTION
改用 @semantic-release/exec 进行发布以规避 @semantic-release/npm 在 workspace 环境下的 publish 错误；同时保留 @semantic-release/npm 仅用于写入子包版本（npmPublish=false）。
合并后将再次触发 Release to GH Packages。