### PR TITLE
ci(ghpkgs): exec prepare+publish; drop npm plugin

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -51,7 +51,6 @@ jobs:
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
             @semantic-release/changelog \
-            @semantic-release/npm \
             @semantic-release/exec \
             @semantic-release/git \
             @semantic-release/github

--- a/.releaserc
+++ b/.releaserc
@@ -9,12 +9,9 @@
       { "changelogFile": "mcp/codex-mcp-server/CHANGELOG.md" }
     ],
     [
-      "@semantic-release/npm",
-      { "pkgRoot": "mcp/codex-mcp-server", "npmPublish": false }
-    ],
-    [
       "@semantic-release/exec",
       {
+        "prepareCmd": "node -e \"const fs=require('fs');const p='mcp/codex-mcp-server/package.json';const pkg=JSON.parse(fs.readFileSync(p));pkg.version='${nextRelease.version}';fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+'\\n');console.log('set version to ${nextRelease.version}');\"",
         "publishCmd": "cd mcp/codex-mcp-server && npm publish --registry https://npm.pkg.github.com"
       }
     ],


### PR DESCRIPTION
移除 @semantic-release/npm 以避免 workspace 下 version 流程报错；
改用 @semantic-release/exec 在 prepare 阶段写入子包 version，在 publish 阶段执行 npm publish 到 GH Packages。