### PR TITLE
ci: only run release on PR merged to main

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -1,13 +1,15 @@
 name: Release to GH Packages
 
 on:
-  push:
-    branches:
-      - main
+  # 仅在 PR 合并到 main 时触发（避免普通分支 push 消耗次数）
+  pull_request:
+    types: [closed]
+    branches: [main]
     paths:
       - 'mcp/**'
       - '.releaserc'
       - '.github/workflows/release-ghpkgs.yml'
+  # 仍保留手动触发
   workflow_dispatch: {}
 
 permissions:
@@ -17,11 +19,15 @@ permissions:
 jobs:
   release-ghpkgs:
     runs-on: ubuntu-latest
+    # 仅在 PR 已合并时执行；或手动触发
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # 在合并事件上检出合并提交；手动触发时默认 main
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || 'main' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
将 release-ghpkgs.yml 的触发从 push(main) 改为 pull_request.closed + merged，仅在合并到 main 时运行，避免分支 push 触发。保留 workflow_dispatch 手动触发。