### PR TITLE
feat(ci): sync publish to npmjs (conditional) + ghpkgs

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -43,6 +43,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure npm for npmjs (if NPM_TOKEN present)
+        if: ${{ secrets.NPM_TOKEN != '' }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "$NPM_CONFIG_USERCONFIG"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Install dependencies (mcp package)
         working-directory: mcp/codex-mcp-server
         run: npm ci
@@ -66,4 +73,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -12,6 +12,12 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node -e \"const fs=require('fs');const p='mcp/codex-mcp-server/package.json';const pkg=JSON.parse(fs.readFileSync(p));pkg.version='${nextRelease.version}';fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+'\\n');console.log('set version to ${nextRelease.version}');\"",
+        "publishCmd": "cd mcp/codex-mcp-server && npm publish --registry https://registry.npmjs.org/"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
         "publishCmd": "cd mcp/codex-mcp-server && npm publish --registry https://npm.pkg.github.com"
       }
     ],


### PR DESCRIPTION
在 semantic-release 流程中：
- 使用 @semantic-release/exec 先发布到 npmjs（需 NPM_TOKEN），后发布到 GH Packages；
- 在 CI 注入 //registry.npmjs.org/_authToken 配置（仅当 NPM_TOKEN 存在）；
- 继续保留 workflow_dispatch 与合并触发（合并后触发）。