### PR TITLE
ci: fix GHA secrets context in step if + refine triggers

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - 'mcp/**'
       - '.releaserc'
-    paths-ignore:
-      - '.github/workflows/**'
   workflow_dispatch: {}
 
 permissions:
@@ -21,6 +19,9 @@ jobs:
       group: release-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    env:
+      # 将可选的 NPM_TOKEN 暴露为 env，便于 if 判断
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,11 +43,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure npm for npmjs (if NPM_TOKEN present)
-        if: ${{ secrets.NPM_TOKEN != '' }}
+        if: ${{ env.NPM_TOKEN != '' }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "$NPM_CONFIG_USERCONFIG"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies (mcp package)
         working-directory: mcp/codex-mcp-server


### PR DESCRIPTION
修复 GHA 表达式错误：(Line: 45) Unrecognized named-value: secrets。
- 将 step if 从 secrets.NPM_TOKEN 切换到 env.NPM_TOKEN（通过 job env 注入）；
- 仅在 main + 路径 mcp/** 与 .releaserc 变更时触发，避免空跑；
- 保留 workflow_dispatch；
- 继续使用 concurrency 防重复运行。