### PR TITLE
ci: remove step if using secrets; use shell conditional instead

### DIFF
--- a/.github/workflows/release-ghpkgs.yml
+++ b/.github/workflows/release-ghpkgs.yml
@@ -42,10 +42,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure npm for npmjs (if NPM_TOKEN present)
-        if: ${{ env.NPM_TOKEN != '' }}
+      - name: Configure npm for npmjs (conditional)
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "$NPM_CONFIG_USERCONFIG"
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "$NPM_CONFIG_USERCONFIG"
+          fi
 
       - name: Install dependencies (mcp package)
         working-directory: mcp/codex-mcp-server


### PR DESCRIPTION
修复 GHA 语法校验：不再在 step if 中引用 secrets/env，改为在 shell 中判断 NPM_TOKEN 是否存在；避免 Invalid workflow file 错误。