### PR TITLE
ci(release): 改为 npmjs 自动发布 + GitHub Release 附 .tgz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,20 @@
-name: Release to GH Packages
+name: Release
 
 on:
-  # 简化触发：仅 main 分支 push（通常来自 PR 合并）+ 手动触发
   push:
     branches: [main]
-    paths:
-      - 'mcp/**'
-      - '.releaserc'
   workflow_dispatch: {}
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
-  release-ghpkgs:
+  release:
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      # 将可选的 NPM_TOKEN 暴露为 env，便于 if 判断
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout
@@ -34,18 +28,13 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Configure npm for GitHub Packages
-        run: |
-          echo "@yuanyuanyuan:registry=https://npm.pkg.github.com" >> "$NPM_CONFIG_USERCONFIG"
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> "$NPM_CONFIG_USERCONFIG"
-          echo "always-auth=true" >> "$NPM_CONFIG_USERCONFIG"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure npm for npmjs (conditional)
+      - name: Configure npm for npmjs
         run: |
           if [ -n "${NPM_TOKEN:-}" ]; then
             echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "$NPM_CONFIG_USERCONFIG"
+            echo "always-auth=true" >> "$NPM_CONFIG_USERCONFIG"
+          else
+            echo "NPM_TOKEN not set; npm publish will be skipped by semantic-release."
           fi
 
       - name: Install dependencies (mcp package)
@@ -67,9 +56,9 @@ jobs:
             @semantic-release/git \
             @semantic-release/github
 
-      - name: Semantic Release (publish to GH Packages)
+      - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+

--- a/.releaserc
+++ b/.releaserc
@@ -11,14 +11,8 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "node -e \"const fs=require('fs');const p='mcp/codex-mcp-server/package.json';const pkg=JSON.parse(fs.readFileSync(p));pkg.version='${nextRelease.version}';fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+'\\n');console.log('set version to ${nextRelease.version}');\"",
-        "publishCmd": "cd mcp/codex-mcp-server && npm publish --registry https://registry.npmjs.org/"
-      }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        "publishCmd": "cd mcp/codex-mcp-server && npm publish --registry https://npm.pkg.github.com"
+        "prepareCmd": "bash -lc 'node -e \"const fs=require(\\\"fs\\\");const p=\\\"mcp/codex-mcp-server/package.json\\\";const pkg=JSON.parse(fs.readFileSync(p));pkg.version=\\\"${nextRelease.version}\\\";fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+\\\"\\n\\\");console.log(\\\"set version to ${nextRelease.version}\\\");\"; cd mcp/codex-mcp-server && npm pack'",
+        "publishCmd": "bash -lc 'if [ -n \"${NPM_TOKEN:-}\" ]; then cd mcp/codex-mcp-server && npm publish --access public --registry https://registry.npmjs.org/; else echo \"[semantic-release] skip npmjs publish: NPM_TOKEN missing\"; fi'"
       }
     ],
     [
@@ -28,9 +22,13 @@
           "mcp/codex-mcp-server/CHANGELOG.md",
           "mcp/codex-mcp-server/package.json"
         ],
-        "message": "chore(release): mcp v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): mcp v${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      { "assets": [{ "path": "mcp/codex-mcp-server/*.tgz" }] }
+    ]
   ]
 }
+


### PR DESCRIPTION
- 新增 .github/workflows/release.yml（push main + workflow_dispatch）\n- 删除 GH Packages 工作流\n- .releaserc: prepare 写版本并 npm pack；仅 npmjs 发布（Automation NPM_TOKEN）；GitHub Release 上传 tgz\n\n合并后：合并到 main 的 fix/feat/BREAKING 提交将自动发布 npmjs，并在 GitHub 打 tag + 创建 Release（附 .tgz）。