### PR TITLE
fix(release): 修复 publishCmd 模板变量以恢复 npm 发布

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -12,7 +12,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "bash -lc 'node -e \"const fs=require(\\\"fs\\\");const p=\\\"mcp/codex-mcp-server/package.json\\\";const pkg=JSON.parse(fs.readFileSync(p));pkg.version=\\\"${nextRelease.version}\\\";fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+\\\"\\n\\\");console.log(\\\"set version to ${nextRelease.version}\\\");\"; cd mcp/codex-mcp-server && npm pack'",
-        "publishCmd": "bash -lc 'if [ -n \"${NPM_TOKEN:-}\" ]; then cd mcp/codex-mcp-server && npm publish --access public --registry https://registry.npmjs.org/; else echo \"[semantic-release] skip npmjs publish: NPM_TOKEN missing\"; fi'"
+        "publishCmd": "bash -lc 'if [ -n \"$NPM_TOKEN\" ]; then cd mcp/codex-mcp-server && npm publish --access public --registry https://registry.npmjs.org/; else echo \"[semantic-release] skip npmjs publish: NPM_TOKEN missing\"; fi'"
       }
     ],
     [
@@ -31,4 +31,3 @@
     ]
   ]
 }
-


### PR DESCRIPTION
- 根因：@semantic-release/exec 对字符串做 lodash.template 处理，`` 被解析为表达式，导致 SyntaxError。\n- 修复：改用 [ -n "" ] 判断，避免模板插值冲突。\n\n合并到 main 后应触发 patch 版本（1.1.2）发布：\n- 打 tag：mcp-v1.1.2\n- GitHub Release（上传 mcp/codex-mcp-server/*.tgz）\n- npmjs 发布（使用仓库 NPM_TOKEN）