### PR TITLE
ci(release): 注入 NODE_AUTH_TOKEN + 输出 npm whoami（修复 npm 发布鉴权）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           else
             echo "NPM_TOKEN not set; npm publish will be skipped by semantic-release."
           fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies (mcp package)
         working-directory: mcp/codex-mcp-server
@@ -56,9 +58,12 @@ jobs:
             @semantic-release/git \
             @semantic-release/github
 
+      - name: Debug npm identity
+        run: npm whoami || true
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
-


### PR DESCRIPTION
 - 在 Release 步骤注入 NODE_AUTH_TOKEN=secrets.NPM_TOKEN，npm 将优先使用该变量鉴权
 - npmrc 步骤显式传入 NPM_TOKEN env，避免 Job Env 在子 Shell 中缺失
 - 新增 debug 步骤：npm whoami（帮助确认 Token 归属账号）

合并后再次触发发布，可验证 npm publish 是否恢复。