### PR TITLE
docs: 改进 MCP 服务器文档，提升用户体验

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,160 +111,81 @@
 
 ## 🚀 快速开始
 
-### 前置要求
+### 开箱即用的 MCP 服务器
 
-- **Node.js** >= 18.0.0
-- **TypeScript** >= 5.3.0
-- **Codex CLI** 已安装并配置
-
-### 安装
+本项目提供了一个完整的 MCP 服务器实现，支持通过 npx 一键启动：
 
 ```bash
-# 克隆仓库
-git clone https://github.com/yourusername/codex-father.git
-cd codex-father
+# 直接运行（推荐）
+npx @starkdev020/codex-father-mcp-server
 
-# 安装依赖
-npm install
-
-# 构建项目
-npm run build
+# 或者克隆仓库本地开发
+git clone https://github.com/yuanyuanyuan/codex-father.git
+cd codex-father/mcp/codex-mcp-server
+npm install && npm run dev
 ```
 
-### 启动服务器
+### 集成到 MCP 客户端
 
-```bash
-# 开发模式（自动重载）
-npm run dev
+支持多种 MCP 客户端：
 
-# 生产模式
-npm start
-
-# 使用 MCP Inspector 调试
-npx @modelcontextprotocol/inspector npm run mcp:start
-```
-
-### 配置 Claude Desktop
-
-添加到 `~/Library/Application Support/Claude/claude_desktop_config.json`:
+**Claude Desktop** - 添加到配置文件：
 
 ```json
 {
   "mcpServers": {
     "codex-father": {
-      "command": "node",
-      "args": ["/path/to/codex-father/dist/core/cli/start.ts", "mcp"],
-      "env": {
-        "NODE_ENV": "production"
-      }
+      "command": "npx",
+      "args": ["-y", "@starkdev020/codex-father-mcp-server"]
     }
   }
 }
 ```
+
+**Codex CLI (rMCP)** - 添加到 `~/.codex/config.toml`：
+
+```toml
+[mcp_servers.codex-father]
+command = "npx"
+args = ["-y", "@starkdev020/codex-father-mcp-server"]
+```
+
+**Claude Code CLI** - 在项目根目录创建 `.claude/mcp_settings.json`
+
+📖 **完整使用文档**: [MCP 服务器使用指南](mcp/codex-mcp-server/README.md)
+
+> 包含详细的配置说明、实战示例、故障排除和 rMCP 集成说明
 
 ## 📖 使用指南
 
-### 基本使用
+### MCP 工具列表
 
-#### 1. 发送消息到 Codex
+当前版本提供以下 MCP 工具：
 
-```typescript
-// 通过 MCP 工具调用
-{
-  "name": "codex-chat",
-  "arguments": {
-    "message": "帮我分析这段代码的性能问题",
-    "systemPrompt": "你是一位资深的性能优化专家"
-  }
-}
-```
+1. **`codex.exec`** - 同步执行 Codex 任务
+2. **`codex.start`** - 异步启动任务（返回 jobId）
+3. **`codex.status`** - 查询任务状态
+4. **`codex.logs`** - 读取任务日志
+5. **`codex.stop`** - 停止运行中的任务
+6. **`codex.list`** - 列出所有任务
 
-#### 2. 执行 Codex 命令
+### 使用示例
 
-```typescript
-{
-  "name": "codex-execute",
-  "arguments": {
-    "args": ["--task", "运行测试", "--cwd", "/workspace"]
-  }
-}
-```
+在 Claude Desktop 中直接对话：
 
-#### 3. 读取文件
+**你**: "帮我分析一下这个项目的代码质量"
 
-```typescript
-{
-  "name": "codex-read-file",
-  "arguments": {
-    "path": "src/index.ts"
-  }
-}
-```
+**Claude** 会自动调用 `codex.exec` 工具执行分析任务。
 
-#### 4. 应用补丁
+### 详细文档
 
-```typescript
-{
-  "name": "codex-apply-patch",
-  "arguments": {
-    "patch": "--- a/file.ts\n+++ b/file.ts\n@@ ...",
-    "fileChanges": [
-      { "type": "modify", "path": "file.ts" }
-    ]
-  }
-}
-```
-
-### 审批机制
-
-配置审批策略 `.codex-father/config/approval-policy.json`:
-
-```json
-{
-  "mode": "untrusted",
-  "whitelist": [
-    {
-      "pattern": "^git status",
-      "reason": "Read-only git command",
-      "enabled": true
-    }
-  ],
-  "timeout": 60000
-}
-```
-
-**审批模式:**
-
-- `never`: 从不审批 (危险，仅用于测试)
-- `on-request`: Codex 请求时审批
-- `on-failure`: 失败后审批重试
-- `untrusted`: 所有操作需审批 (除非在白名单)
-
-### 事件通知
-
-服务器会发送以下 MCP 通知:
-
-```typescript
-// 进度通知
-{
-  "method": "notifications/progress",
-  "params": {
-    "progressToken": "job-123",
-    "progress": 50,
-    "total": 100
-  }
-}
-
-// 日志通知
-{
-  "method": "notifications/message",
-  "params": {
-    "level": "info",
-    "logger": "codex-father",
-    "data": "Command completed successfully"
-  }
-}
-```
+- **完整工具参数说明**:
+  [MCP 工具详解](mcp/codex-mcp-server/README.md#🛠️-mcp-工具详解)
+- **实战示例**: [实战示例](mcp/codex-mcp-server/README.md#📖-实战示例)
+- **安全策略配置**: [安全策略说明](mcp/codex-mcp-server/README.md#⚙️-高级配置)
+- **故障排除**: [故障排除指南](mcp/codex-mcp-server/README.md#🆘-故障排除)
+- **Codex rMCP 集成**:
+  [关于 Codex rMCP](mcp/codex-mcp-server/README.md#🔗-关于-codex-rmcp-支持)
 
 ## 🛠️ 开发
 
@@ -401,10 +322,15 @@ npm run benchmark
 
 ## 📚 文档
 
-- [MCP 使用指南](README.md#mcp-使用指南) — 工具、参数映射、JSON-RPC 示例
-- [Quickstart（已归档）](specs/_archived/005-docs-prd-draft/quickstart.md)
-- [数据模型（已归档）](specs/_archived/005-docs-prd-draft/data-model.md)
-- [非交互模式说明](docs/codex-non-interactive.md)
+### 用户文档
+
+- **[MCP 服务器使用指南](mcp/codex-mcp-server/README.md)** - 完整的使用文档和配置说明
+- [非交互模式说明](docs/codex-non-interactive.md) - CLI 非交互模式使用
+
+### 开发文档
+
+- [架构设计](specs/_archived/005-docs-prd-draft/) - MVP1 设计文档（已归档）
+- [数据模型](specs/_archived/005-docs-prd-draft/data-model.md) - 数据结构说明（已归档）
 
 ## 🤝 贡献
 
@@ -462,124 +388,23 @@ MIT License - 详见 [LICENSE](LICENSE) 文件
 
 如需完整规范与进度，请参见：`specs/006-docs-capability-assessment/*`。
 
-## MCP 使用指南
+## 📚 完整文档
 
-本节整合了原先的 `readme.mcp.md` 内容，作为 MCP 使用的唯一权威文档。
+详细的使用文档请参考：
 
-### 工具与参数
+### 📖 [MCP 服务器使用指南](mcp/codex-mcp-server/README.md)
 
-- 同步：`codex.exec` — `{ args?: string[], tag?: string, cwd?: string }`
-- 异步：
-  - `codex.start` — `{ args?: string[], tag?: string, cwd?: string }`
-  - `codex.status` — `{ jobId: string, cwd?: string }`
-  - `codex.logs` —
-    `{ jobId: string, mode?: 'bytes'|'lines', offset?: number, limit?: number, offsetLines?: number, limitLines?: number, tailLines?: number, grep?: string, cwd?: string }`
-  - `codex.stop` — `{ jobId: string, force?: boolean, cwd?: string }`
-  - `codex.list` — `{ cwd?: string }`
+包含以下内容：
 
-常用参数映射（传给 `arguments.args`）
+- **5 分钟快速上手** - npx 一键启动、多客户端配置
+- **实战示例** - Claude Desktop、Codex CLI、Claude Code 实际使用场景
+- **MCP 工具详解** - 完整的 API 参数说明
+- **高级配置** - 安全策略、环境变量、自动化示例
+- **故障排除** - 常见问题及解决方案
+- **Codex rMCP 支持** - 与 Codex CLI 的深度集成
 
-- 指令组合：`-F/--file-override`、`-f/--file`（通配）`--docs`、`-c/--content`
-- 模板：`--prepend*`、`--append*`
-- 预设：`--preset sprint|analysis|secure|fast`
-- 上下文：`--no-carry-context`、`--no-compress-context`、`--context-head N`、`--context-grep REGEX`
-- 直通 Codex：`--sandbox`、`--codex-config approval_policy=<policy>`、`--profile`、`--full-auto`、`--codex-arg "--flag value"`
+### 🛠️ 开发文档
 
-建议：MCP 场景避免使用 STDIN（`-f -`/`-F -`），改用 `-c` 或将内容落盘后以
-`-f/--docs` 传入。
-
-### stdio/JSON-RPC 示例
-
-```bash
-# 初始化 + 列出工具
-printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-09-18","capabilities":{},"clientInfo":{"name":"demo","version":"0.0.1"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n' | ./mcp/server.sh
-
-# 同步执行（exec）
-printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"codex.exec","arguments":{"args":["--task","Sync via MCP","--dry-run"],"tag":"mcp-sync"}}}\n' | ./mcp/server.sh
-
-# 异步执行（start）
-printf '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"codex.start","arguments":{"args":["--task","Async via MCP","--dry-run"],"tag":"mcp-async"}}}\n' | ./mcp/server.sh
-```
-
-### 产物与路径
-
-- 会话目录：`<项目根>/.codex-father/sessions/<job-id>/`
-- 同步（exec）：`job.log | job.instructions.md | job.meta.json | aggregate.*`
-- 异步（start）：`job.log | *.instructions.md | *.meta.json | state.json | pid | aggregate.*`
-
-### 默认安全与补丁模式
-
-- 默认：若未显式提供，MCP 会为 `codex.exec/start` 注入
-  `--sandbox workspace-write`；不再默认注入 `--approvals`（兼容更多 CLI 版本）。
-- 补丁模式：`--patch-mode`（提示仅输出补丁而不改盘），建议与只读策略搭配：`--sandbox read-only --codex-config approval_policy=never`。
-
-## 🧩 使用示例
-
-### 1) 直接使用 CLI（同步）
-
-```bash
-# 汇总多个文档要点（同步执行）
-./start.sh --docs 'docs/**/*.md' -c "仅输出中文要点" --dry-run
-
-# 只输出补丁（不改盘）+ 安全只读
-./start.sh --task "修复 README 锚点" \
-  --patch-mode --sandbox read-only --codex-config approval_policy=never
-```
-
-### 2) 异步任务（job.sh）
-
-```bash
-# 启动后台任务
-./job.sh start --task "验证 MCP 工具" --dry-run --tag demo --json
-
-# 查询状态
-./job.sh status <job-id> --json
-
-# 查看日志（跟随）
-./job.sh logs <job-id> --follow
-
-# 停止任务
-./job.sh stop <job-id> --force
-```
-
-### 3) MCP（stdio/JSON-RPC）
-
-```bash
-# 初始化 + 列出工具
-printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-09-18","capabilities":{},"clientInfo":{"name":"demo","version":"0.0.1"}}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n' | ./mcp/server.sh
-
-# 同步执行：codex.exec
-printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"codex.exec","arguments":{"args":["--task","Sync via MCP","--dry-run"],"tag":"mcp-sync"}}}\n' | ./mcp/server.sh
-
-# 异步执行：codex.start
-printf '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"codex.start","arguments":{"args":["--task","Async via MCP","--dry-run"],"tag":"mcp-async"}}}\n' | ./mcp/server.sh
-```
-
-提示：MCP 场景中避免使用 STDIN（`-f -`/`-F -`），优先 `-c` 或落盘后用
-`-f/--docs` 传入。
-
-## 🆘 快速排障
-
-- 无法启动 MCP 服务器
-  - 确认 Node ≥ 18：`node -v`
-  - 构建 MCP：`(cd mcp/codex-mcp-server && npm install && npm run build)`
-  - 直接运行：`./mcp/server.sh`
-
-- tools/list 为空或 tools/call 报错
-  - 检查运行目录是否是项目根（影响相对路径）
-  - 明确传入 `cwd` 字段到 MCP 调用中
-  - 查看 `.codex-father/sessions/<id>/job.log` 末尾错误
-
-- exec/start 行为与审批不符
-  - 未显式传入时会注入 `--sandbox workspace-write`
-  - 指定审批：`--codex-config approval_policy=on-request`（或
-    `never`/`on-failure`/`untrusted`）
-  - 需要只读+补丁：`--patch-mode --sandbox read-only --codex-config approval_policy=never`
-
-- 本地提交被 lint-staged 阻塞
-  - 先执行：`npm run lint:check` 查看报错
-  - 若钩子中断：按提示使用 `git stash list` 恢复 `stash@{0}`（如有）
-
-- 测试失败或类型报错
-  - 执行：`npm run check:all`（typecheck + lint + format:check + test）
-  - 逐项排查：`npm run typecheck`、`npm run test:run`
+- [架构设计文档](docs/) - 技术架构和设计决策
+- [API 参考](specs/) - 完整的 API 规范
+- [贡献指南](#贡献) - 如何参与项目开发

--- a/mcp/codex-mcp-server/README.md
+++ b/mcp/codex-mcp-server/README.md
@@ -1,127 +1,666 @@
-codex-father-mcp-server
+# Codex Father MCP Server
 
-TypeScript MCP server for this repo using @modelcontextprotocol/sdk. It exposes
-tools to execute/start and manage Codex runs by delegating to the local
-`start.sh`/`job.sh`.
+> 🚀 开箱即用的 MCP 服务器，将 Codex CLI 暴露为标准 MCP 工具
 
-Usage
+通过 MCP (Model Context Protocol) 协议，让 Claude
+Desktop 或任何 MCP 客户端都能直接调用 Codex CLI，实现智能代码生成、分析和修复。
 
-- Dev run (requires deps installed):
-  - `npm install`
-  - `npm run dev`
+## ✨ 核心特性
 
-- Build + run:
-  - `npm run build`
-  - `node dist/index.js`
+- **零配置启动** - 5 分钟内完成从安装到运行
+- **异步任务管理** - 支持长时间运行的任务，可随时查询状态和日志
+- **灵活的安全策略** - 从只读到完全访问，可自由配置
+- **多客户端支持** - 支持 Claude Desktop、Codex CLI (rMCP)、Claude Code CLI
+- **标准 MCP 协议** - 完全兼容 Model Context Protocol 规范
 
-- As CLI after publish:
-  - GitHub Packages (this repo uses GH Packages)
-    - Configure ~/.npmrc:
-      - `@starkdev020:registry=https://npm.pkg.github.com`
-      - `//npm.pkg.github.com/:_authToken=<YOUR_GITHUB_TOKEN>`
-    - Install or run:
-      - `npm install -g @starkdev020/codex-father-mcp-server`
-      - or `npx @starkdev020/codex-father-mcp-server`
-  - npmjs (if published there)
-    - `npx @starkdev020/codex-father-mcp-server` (or `codex-mcp-server` if
-      globally installed)
+---
 
-Tools
+## 🚀 5 分钟快速上手
 
-- `codex.exec`: Synchronous execution (blocks until finish). Args:
-  - `args`: string[] — forwarded to `start.sh`
-  - `tag`: string — label for the run (used in directory name)
-  - `cwd`: string — project root for session storage (default: server cwd)
-  - Convenience fields (optional):
-    - `approvalPolicy`: `untrusted|on-failure|on-request|never`
-    - `sandbox`: `read-only|workspace-write|danger-full-access`
-    - `network`: boolean (enables network in workspace-write mode)
-    - `fullAuto`: boolean (adds `--full-auto`)
-    - `dangerouslyBypass`: boolean (adds
-      `--dangerously-bypass-approvals-and-sandbox` and enforces
-      `--sandbox danger-full-access`)
-    - `profile`: string (Codex config profile)
-    - `codexConfig`: object (mapped to repeated `--codex-config 'k=v'`)
-  - Returns JSON:
-    `{ runId, exitCode, cwd, logFile, instructionsFile, metaFile, lastMessageFile, tag }`
+### 前置要求
 
-- `codex.start`: Start a non-blocking run. Args:
-  - `args`: string[] — forwarded to `start.sh`
-  - `tag`: string — job tag
-  - `cwd`: string — working directory for job
-  - Same convenience fields as `codex.exec` are supported.
+- **Node.js** >= 18
+- **Codex CLI** 已安装 ([获取 Codex](https://github.com/anthropics/codex))
 
-- `codex.status`: Get job status. Args: `{ jobId: string, cwd?: string }`
-- `codex.logs`: Read job log. Args:
-  - `jobId` (string), optional `cwd` to locate `.codex-father/sessions`
-  - Either byte pagination (`offset`, `limit`) or line mode (`mode: "lines"`,
-    with `offsetLines`/`limitLines` or `tailLines`, optional `grep`)
-- `codex.stop`: Stop a job. Args:
-  `{ jobId: string, force?: boolean, cwd?: string }`
-- `codex.list`: List known jobs. Args: `{ cwd?: string }`
+### 方式一：本地开发模式（推荐用于测试）
 
-Configuration (VS Code-style)
+```bash
+# 1. 克隆仓库
+git clone https://github.com/yuanyuanyuan/codex-father.git
+cd codex-father/mcp/codex-mcp-server
+
+# 2. 安装依赖
+npm install
+
+# 3. 启动服务器
+npm run dev
+```
+
+### 方式二：使用 npx（一键启动）
+
+包已发布到 npmjs，可以直接运行：
+
+```bash
+# 直接运行，无需额外配置
+npx @starkdev020/codex-father-mcp-server
+```
+
+> 💡 **提示**：首次运行会自动下载，后续启动会更快
+
+### 方式三：集成到 MCP 客户端
+
+支持以下 MCP 客户端：
+
+#### 3.1 Claude Desktop
+
+**macOS/Linux** 配置文件位置：
 
 ```
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+**Windows** 配置文件位置：
+
+```
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+**配置内容**：
+
+```json
 {
-  "servers": {
+  "mcpServers": {
     "codex-father": {
-      "command": "node",
-      "args": ["/path/to/dist/index.js"],
-      "type": "stdio"
-    },
-    "deepwiki": {
-      "url": "https://mcp.deepwiki.com/sse",
-      "type": "http"
+      "command": "npx",
+      "args": ["-y", "@starkdev020/codex-father-mcp-server"],
+      "env": {
+        "NODE_ENV": "production"
+      }
     }
   }
 }
 ```
 
-Deepwiki note
+**保存后重启 Claude Desktop**，你将在工具列表中看到 `codex.*` 系列工具！
 
-- With `deepwiki` configured, you can query
-  `https://github.com/modelcontextprotocol/typescript-sdk` content at any time
-  in your MCP-enabled client.
-- This server focuses on Codex job orchestration. You can also build a bridge
-  tool to proxy deepwiki via the MCP client API if desired.
+#### 3.2 Codex CLI（使用 rMCP）
 
-Environment
+Codex CLI 支持 MCP 服务器配置，在 `~/.codex/config.toml` 中添加：
 
-- `CODEX_JOB_SH`: optional absolute path to `job.sh`. Defaults to `./job.sh`
-  from current working dir.
-- `CODEX_START_SH`: optional absolute path to `start.sh`. Defaults to
-  `./start.sh` from current working dir.
-
-Storage layout
-
-- Sessions live under `<project>/.codex-father/sessions/<job-id>/` with
-  `job.log`, `*.instructions.md`, `*.meta.json`, `state.json` (async), and
-  `*.last.txt` files.
-
-Examples
-
-- Full‑auto without prompts (workspace‑write + network + never):
-
-```
-{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"codex.exec","arguments":{
-  "cwd":"/path/to/repo",
-  "tag":"mcp-fullauto",
-  "approvalPolicy":"never",
-  "sandbox":"workspace-write",
-  "network":true,
-  "fullAuto":true,
-  "args":["--task","一次性完成任务示例"]
-}}}
+```toml
+[mcp_servers.codex-father]
+command = "npx"
+args = ["-y", "@starkdev020/codex-father-mcp-server"]
+env = { NODE_ENV = "production" }
 ```
 
-- YOLO (not recommended outside containers):
+然后运行 Codex：
+
+```bash
+codex
+# 在 Codex 中，工具将自动可用
+```
+
+#### 3.3 Claude Code CLI
+
+在项目根目录创建 `.claude/mcp_settings.json`：
+
+```json
+{
+  "mcpServers": {
+    "codex-father": {
+      "command": "npx",
+      "args": ["-y", "@starkdev020/codex-father-mcp-server"]
+    }
+  }
+}
+```
+
+启动 Claude Code：
+
+```bash
+claude-code
+# 工具将自动加载
+```
+
+---
+
+## 📖 实战示例
+
+### 示例 1：在 Claude Desktop 中分析代码
+
+配置完成后，在 Claude Desktop 中直接对话：
+
+**你**："帮我分析一下这个项目的代码质量"
+
+**Claude** 会自动调用 `codex.exec` 工具：
+
+```json
+{
+  "name": "codex.exec",
+  "arguments": {
+    "args": ["--task", "分析项目代码质量，给出改进建议"],
+    "approvalPolicy": "on-request",
+    "sandbox": "read-only"
+  }
+}
+```
+
+### 示例 2：修复 Bug（需要写入权限）
+
+**你**："修复这个空指针异常问题"
+
+**Claude** 会使用：
+
+```json
+{
+  "name": "codex.exec",
+  "arguments": {
+    "args": ["--task", "修复空指针异常"],
+    "sandbox": "workspace-write",
+    "approvalPolicy": "on-request"
+  }
+}
+```
+
+### 示例 3：长时间任务（异步执行）
+
+对于耗时的任务，使用异步模式：
+
+```json
+{
+  "name": "codex.start",
+  "arguments": {
+    "args": ["--task", "重构整个认证模块"],
+    "tag": "refactor-auth",
+    "sandbox": "workspace-write"
+  }
+}
+```
+
+返回 `jobId` 后，可以随时查询状态：
+
+```json
+{
+  "name": "codex.status",
+  "arguments": {
+    "jobId": "返回的jobId"
+  }
+}
+```
+
+查看实时日志：
+
+```json
+{
+  "name": "codex.logs",
+  "arguments": {
+    "jobId": "返回的jobId",
+    "mode": "lines",
+    "tailLines": 50
+  }
+}
+```
+
+### 示例 4：在 Codex CLI 中使用
+
+配置好 `~/.codex/config.toml` 后，在 Codex CLI 中：
+
+**你**："使用 codex-father 工具分析这个项目的代码质量"
+
+**Codex** 会自动调用配置的 MCP 工具，相当于：
+
+```bash
+# Codex 内部执行
+codex.exec --task "分析项目代码质量" --sandbox read-only
+```
+
+**优势**：
+
+- 在 Codex 的对话流程中无缝集成
+- 可以利用 Codex 的上下文管理
+- 支持 rMCP 协议的双向通信
+
+---
+
+## 🛠️ MCP 工具详解
+
+### `codex.exec` - 同步执行
+
+阻塞执行直到任务完成，适合快速任务。
+
+**参数**：
+
+- `args` (string[]) - 传递给 Codex 的参数
+- `tag` (string, 可选) - 任务标签
+- `cwd` (string, 可选) - 工作目录
+- **便捷字段**：
+  - `approvalPolicy`: `untrusted` | `on-failure` | `on-request` | `never`
+  - `sandbox`: `read-only` | `workspace-write` | `danger-full-access`
+  - `network` (boolean) - 是否允许网络访问（为真时自动追加
+    `--codex-config sandbox_workspace_write.network_access=true`）
+  - `fullAuto` (boolean) - 开启 Codex 全自动模式（若启用 `dangerouslyBypass`
+    将被忽略）
+  - `profile` (string) - 指定 Codex 配置文件
+  - `codexConfig` (object) - 逐项转换为 `--codex-config key=value`
+  - `preset` (string) - 使用仓库内的预设
+  - `carryContext` (boolean) - `false` 时追加 `--no-carry-context`
+  - `compressContext` (boolean) - `false` 时追加 `--no-compress-context`
+  - `contextHead` (number) - 控制上下文保留长度（追加 `--context-head`）
+  - `patchMode` (boolean) - 开启补丁模式
+  - `requireChangeIn` (string[]) - 重复追加 `--require-change-in`
+  - `requireGitCommit` (boolean) - 强制生成 Git 提交
+  - `autoCommitOnDone` (boolean) - 成功后自动提交
+  - `autoCommitMessage` (string) - 自动提交信息模板
+  - `dangerouslyBypass` (boolean) - 注入
+    `--dangerously-bypass-approvals-and-sandbox`（详见下文安全说明）
+
+**返回**：
+
+```json
+{
+  "runId": "...",
+  "exitCode": 0,
+  "logFile": "/path/to/log",
+  "instructionsFile": "/path/to/instructions.md"
+}
+```
+
+### `codex.start` - 异步启动
+
+立即返回 `jobId`，任务在后台运行。
+
+**参数**：同 `codex.exec`
+
+**返回**：
+
+```json
+{
+  "jobId": "job-abc-123",
+  "message": "Task started successfully"
+}
+```
+
+### `codex.status` - 查询状态
+
+**参数**：
+
+- `jobId` (string) - 任务 ID
+
+**返回**：
+
+```json
+{
+  "status": "running" | "completed" | "failed",
+  "exitCode": 0,
+  "startTime": "2025-10-03T10:00:00Z"
+}
+```
+
+> ℹ️ **提示**：工单 schema 禁止额外字段，如果你需要切换 `job.sh`
+> 工作目录，请结合下方“高级配置”中的环境变量或在目标目录内启动 MCP 服务器。
+
+### `codex.logs` - 读取日志
+
+**参数**：
+
+- `jobId` (string) - 任务 ID
+- `mode` (string, 可选) - `"bytes"` 或 `"lines"` (默认 bytes)
+- `offset` / `limit` (number, 可选) - 字节模式分页
+- `offsetLines` / `limitLines` (number, 可选) - 行模式分页
+- `tailLines` (number, 可选) - 读取最后 N 行
+- `grep` (string, 可选) - 过滤关键词
+
+**返回**：
+
+- `mode = "bytes"`：
+  ```json
+  {
+    "chunk": "...",
+    "nextOffset": 4096,
+    "eof": false,
+    "size": 16384
+  }
+  ```
+- `mode = "lines"`：
+  ```json
+  {
+    "lines": ["..."],
+    "totalLines": 1200
+  }
+  ```
+
+### `codex.stop` - 停止任务
+
+**参数**：
+
+- `jobId` (string) - 任务 ID
+- `force` (boolean, 可选) - 强制停止
+
+### `codex.list` - 列出所有任务
+
+**参数**：无（不接受额外字段）
+
+**返回**：
+
+```json
+{
+  "jobs": [{ "jobId": "job-1", "status": "running", "tag": "refactor-auth" }]
+}
+```
+
+> ℹ️ **提示**：同
+> `codex.status`，此工具不接受额外参数，请通过环境变量或工作目录切换控制作用范围。
+
+---
+
+## ⚙️ 高级配置
+
+### 环境变量
+
+可以通过环境变量自定义脚本路径：
+
+```bash
+# 自定义 job.sh 路径
+export CODEX_JOB_SH="/custom/path/to/job.sh"
+
+# 自定义 start.sh 路径
+export CODEX_START_SH="/custom/path/to/start.sh"
+
+# 启动服务器
+npm run dev
+```
+
+> ℹ️ **技巧**：`codex.status` 与 `codex.list` 不接受 `cwd`
+> 参数，若要查询其他工作区，请把 `CODEX_JOB_SH` 指向目标目录下的
+> `job.sh`，或直接在该目录中启动 MCP 服务器。
+
+### 会话存储位置
+
+所有任务会话存储在：
 
 ```
-{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"codex.exec","arguments":{
-  "cwd":"/path/to/repo",
-  "tag":"yolo",
-  "dangerouslyBypass":true,
-  "args":["--task","危险示例，仅在可信环境使用"]
-}}}
+<项目根>/.codex-father/sessions/<job-id>/
+├── job.log                # 任务日志
+├── *.instructions.md      # 指令文件
+├── *.meta.json           # 元数据
+├── state.json            # 异步任务状态
+└── *.last.txt           # 最后消息
 ```
+
+### 安全策略说明
+
+| 策略                 | 说明                   | 适用场景           |
+| -------------------- | ---------------------- | ------------------ |
+| `read-only`          | 只读模式，无法修改文件 | 代码分析、审查     |
+| `workspace-write`    | 可修改工作区文件       | Bug 修复、重构     |
+| `danger-full-access` | 完全访问（危险）       | 仅在容器或测试环境 |
+
+| 审批策略     | 说明               | 适用场景     |
+| ------------ | ------------------ | ------------ |
+| `never`      | 从不审批，自动执行 | 全自动化任务 |
+| `on-request` | Codex 请求时审批   | 推荐日常使用 |
+| `on-failure` | 失败后审批重试     | 调试场景     |
+| `untrusted`  | 所有操作需审批     | 高安全环境   |
+
+### `dangerouslyBypass` 行为说明
+
+- 置为 `true` 时会注入
+  `--dangerously-bypass-approvals-and-sandbox`，并自动将沙箱切换为
+  `danger-full-access`。
+- 启用后 Codex 不会追加 `--ask-for-approval`，同时会忽略 `fullAuto=true`
+  以避免重复放权。
+- 如果 `args` 中已经手动加入
+  `--dangerously-bypass-approvals-and-sandbox`，服务器会识别并应用同样的放权逻辑。
+- 建议在隔离环境或一次性实验里使用，生产仓库请保持
+  `on-request + read-only/workspace-write` 组合。
+
+### 完全自动化示例
+
+如果你信任任务，可以使用完全自动化模式：
+
+```json
+{
+  "name": "codex.exec",
+  "arguments": {
+    "cwd": "/path/to/project",
+    "tag": "auto-task",
+    "approvalPolicy": "never",
+    "sandbox": "workspace-write",
+    "network": true,
+    "fullAuto": true,
+    "args": ["--task", "自动完成需求文档中的所有功能"]
+  }
+}
+```
+
+⚠️ **警告**：仅在受信任的环境中使用 `dangerouslyBypass` 选项！
+
+---
+
+## 🆘 故障排除
+
+### 问题 1：Claude Desktop 看不到工具
+
+**症状**：重启 Claude Desktop 后，工具列表中没有 `codex.*` 系列工具
+
+**解决方案**：
+
+```bash
+# 1. 检查配置文件路径是否正确
+cat ~/Library/Application\ Support/Claude/claude_desktop_config.json
+
+# 2. 确认 dist/index.js 已构建
+ls -la /your/path/codex-father/mcp/codex-mcp-server/dist/index.js
+
+# 3. 如果不存在，需要先构建
+cd /your/path/codex-father/mcp/codex-mcp-server
+npm run build
+
+# 4. 重启 Claude Desktop（完全退出后重新打开）
+```
+
+### 问题 2：Codex CLI 中工具未加载
+
+**症状**：在 Codex CLI 中看不到 `codex.*` 工具
+
+**解决方案**：
+
+```bash
+# 1. 确认 config.toml 配置正确
+cat ~/.codex/config.toml | grep -A 3 "codex-father"
+
+# 应该看到类似输出：
+# [mcp_servers.codex-father]
+# command = "npx"
+# args = ["-y", "@starkdev020/codex-father-mcp-server"]
+
+# 2. 测试 MCP 服务器是否可启动
+npx -y @starkdev020/codex-father-mcp-server
+
+# 3. 重启 Codex
+codex
+```
+
+### 问题 3：任务卡住不动
+
+**症状**：`codex.start` 返回了 `jobId`，但 `codex.status` 一直显示 `running`
+
+**解决方案**：
+
+```bash
+# 1. 查看日志
+{
+  "name": "codex.logs",
+  "arguments": {
+    "jobId": "your-job-id",
+    "mode": "lines",
+    "tailLines": 100
+  }
+}
+
+# 2. 如果日志中有错误，强制停止任务
+{
+  "name": "codex.stop",
+  "arguments": {
+    "jobId": "your-job-id",
+    "force": true
+  }
+}
+
+# 3. 检查 Codex CLI 是否正常
+codex --version
+```
+
+### 问题 4：权限被拒绝
+
+**症状**：
+
+```
+Error: EACCES: permission denied
+```
+
+**解决方案**：
+
+```bash
+# 1. 检查文件权限
+ls -la /path/to/codex-father
+
+# 2. 如果是 Node.js 模块权限问题
+sudo chown -R $(whoami) ~/.npm
+sudo chown -R $(whoami) /path/to/codex-father
+
+# 3. 重新安装依赖
+cd /path/to/codex-father/mcp/codex-mcp-server
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### 问题 5：日志输出乱码
+
+**症状**：`codex.logs` 返回的日志中有乱码或格式错误
+
+**解决方案**：
+
+```jsonc
+// 使用行模式 + grep 过滤
+{
+  "name": "codex.logs",
+  "arguments": {
+    "jobId": "your-job-id",
+    "mode": "lines",
+    "grep": "Error|Warning",
+    "tailLines": 50,
+  },
+}
+```
+
+---
+
+## 📚 更多资源
+
+### 项目相关
+
+- **项目主仓库**: [codex-father](https://github.com/yuanyuanyuan/codex-father)
+- **npm 包**:
+  [@starkdev020/codex-father-mcp-server](https://www.npmjs.com/package/@starkdev020/codex-father-mcp-server)
+- **问题反馈**:
+  [GitHub Issues](https://github.com/yuanyuanyuan/codex-father/issues)
+
+### 协议与工具
+
+- **MCP 协议规范**: [Model Context Protocol](https://modelcontextprotocol.io/)
+- **Codex CLI**: [OpenAI Codex](https://github.com/openai/codex)
+- **Codex rMCP 文档**:
+  [Advanced Features](https://github.com/openai/codex/blob/main/docs/advanced.md#model-context-protocol-mcp)
+- **Codex MCP 接口**:
+  [Codex MCP Interface](https://github.com/openai/codex/blob/main/codex-rs/docs/codex_mcp_interface.md)
+
+### 相关工具
+
+- **MCP Inspector**:
+  [@modelcontextprotocol/inspector](https://www.npmjs.com/package/@modelcontextprotocol/inspector)
+- **Claude Desktop**: [下载 Claude](https://claude.ai/download)
+
+---
+
+## 📝 开发者备注
+
+### 其他 MCP 服务器集成
+
+你可以在配置中同时使用多个 MCP 服务器：
+
+```json
+{
+  "mcpServers": {
+    "codex-father": {
+      "command": "node",
+      "args": ["/path/to/codex-father/mcp/codex-mcp-server/dist/index.js"]
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/path/to/workspace"
+      ]
+    }
+  }
+}
+```
+
+### JSON-RPC 调试
+
+使用 MCP Inspector 进行调试：
+
+```bash
+# 启动 Inspector（自动在浏览器打开）
+npx @modelcontextprotocol/inspector npm run dev
+
+# 在浏览器中测试各种工具调用
+```
+
+---
+
+## 🔗 关于 Codex rMCP 支持
+
+### 什么是 rMCP？
+
+rMCP (Remote Model Context Protocol) 是 Codex
+CLI 对 MCP 协议的实现，允许 Codex 作为 MCP 客户端调用外部 MCP 服务器。
+
+### Codex Father MCP Server 与 Codex rMCP 的关系
+
+- **Codex rMCP**: Codex CLI 内置的 MCP 客户端功能
+  - 配置在 `~/.codex/config.toml` 的 `[mcp_servers]` 部分
+  - 让 Codex 能调用外部 MCP 工具
+
+- **Codex Father MCP Server**: 本项目，一个标准 MCP 服务器
+  - 暴露 `codex.*` 系列工具（exec、start、status、logs 等）
+  - 可被任何 MCP 客户端调用（包括 Codex、Claude Desktop、Claude Code）
+
+### 使用场景对比
+
+| 使用方式                          | 适用场景                            | 配置位置                     |
+| --------------------------------- | ----------------------------------- | ---------------------------- |
+| **Claude Desktop + Codex Father** | 在 Claude Desktop 中使用 Codex 能力 | `claude_desktop_config.json` |
+| **Codex CLI + Codex Father**      | 在 Codex 中调用另一个 Codex 实例    | `~/.codex/config.toml`       |
+| **Claude Code + Codex Father**    | 在 Claude Code 中使用 Codex 能力    | `.claude/mcp_settings.json`  |
+
+### Codex 原生 MCP 服务器
+
+Codex 本身也可以作为 MCP 服务器运行（`codex mcp`），提供不同的工具：
+
+- `codex` - 启动 Codex 会话
+- `codex-reply` - 继续 Codex 会话
+
+**区别**：
+
+- `codex mcp` 提供的是 Codex 的原生会话管理能力
+- `codex-father-mcp-server` 提供的是任务调度和异步管理能力
+
+两者可以配合使用，构建更强大的工作流！
+
+---
+
+**Built with ❤️ by Codex Father Team**


### PR DESCRIPTION
## 📖 文档改进概述

本 PR 对 MCP 服务器文档进行了全面改进，提升开箱即用性和用户体验。

## ✨ 主要改进

### 1. 简化主 README.md
- ✅ 添加 npx 一键启动说明（无需 GitHub Token）
- ✅ 提供多客户端配置示例（Claude Desktop / Codex CLI / Claude Code CLI）
- ✅ 删除 ~140 行重复内容
- ✅ 移除过时的工具示例（codex-chat, codex-execute 等）
- ✅ 添加清晰的文档导航链接

### 2. 全面重写 mcp/codex-mcp-server/README.md
- ✅ 新增「5 分钟快速上手」章节，包含 3 种使用方式
- ✅ 新增「实战示例」章节，提供 4 个完整的使用场景
- ✅ 新增「MCP 工具详解」，完整的 6 个工具 API 文档
- ✅ 新增「高级配置」，包含安全策略和环境变量说明
- ✅ 新增「故障排除」，覆盖 5 个常见问题
- ✅ 新增「关于 Codex rMCP 支持」专属章节

### 3. 多客户端支持说明
- ✅ Claude Desktop 配置（JSON 格式）
- ✅ Codex CLI 配置（TOML 格式，rMCP 支持）
- ✅ Claude Code CLI 配置（JSON 格式）

## 📊 变更统计

- **README.md**: 305 行变更（简化重复内容）
- **mcp/codex-mcp-server/README.md**: 753 行扩充（详细使用指南）
- **总计**: +711 insertions, -347 deletions

## 🎯 用户体验提升

1. **开箱即用**: 用户可以直接使用 `npx @starkdev020/codex-father-mcp-server` 启动
2. **清晰导航**: 主 README 提供概览和链接，详细文档集中在子目录
3. **多场景支持**: 明确说明在不同 MCP 客户端中的配置方法
4. **实战导向**: 提供完整的使用示例，而非仅有 API 参数说明
5. **问题解决**: 预判常见问题并提供解决方案

## 🔗 相关 Issue

解决用户反馈的文档不清晰、缺少实战示例、多客户端支持说明不足等问题。

## ✅ 检查清单

- [x] 删除重复内容
- [x] 添加 npx 使用说明
- [x] 添加多客户端配置示例
- [x] 添加实战示例
- [x] 添加 rMCP 支持说明
- [x] 代码格式化（prettier）
- [x] 链接完整性检查