### PR TITLE
ci(npm): fix release workflow npm ci by aligning typedoc with lock (^0.25.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "rimraf": "^5.0.5",
     "supertest": "^7.1.4",
     "tsx": "^4.6.0",
-    "typedoc": "^0.28.0",
+    "typedoc": "^0.25.4",
     "typescript": "^5.9.3",
     "vite": "^5.0.0",
     "vitest": "^1.0.0"


### PR DESCRIPTION
This PR fixes the failing Release workflow step 'Install dependencies (mcp package)'.\n\n- Root package.json typedoc set to ^0.25.4 to match package-lock.json (0.25.13)\n- npm ci will no longer error with EUSAGE lock mismatch.\n- Combined with existing --legacy-peer-deps, this unblocks the CI without changing lock.\n\nAfter merge: re-run the failed run or push to main to trigger a new release (mcp-v1.4.0).