### PR TITLE
test(orchestrator): add red tests for T025–T027

### DIFF
--- a/core/orchestrator/tests/patch-applier.test.ts
+++ b/core/orchestrator/tests/patch-applier.test.ts
@@ -1,13 +1,125 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PatchApplier } from '../patch-applier';
+import type { PatchApplyResult, PatchProposal } from '../types';
 
-describe('patch-applier', () => {
-  it('导出 PatchApplier 类', () => {
-    expect(typeof PatchApplier).toBe('function');
+type StrategyResult = PatchApplyResult & {
+  strategy?: 'git' | 'native';
+  usedFallback?: boolean;
+};
+
+type ApplyOptions = {
+  gitApplyAvailable?: boolean;
+  fallbackToNative?: boolean;
+  strategies: {
+    git: (proposal: PatchProposal) => Promise<StrategyResult>;
+    native: (proposal: PatchProposal) => Promise<StrategyResult>;
+  };
+};
+
+describe('PatchApplier 策略分支', () => {
+  const buildProposal = (overrides: Partial<PatchProposal> = {}): PatchProposal => ({
+    id: overrides.id ?? 'patch_demo',
+    targetFiles: overrides.targetFiles ?? ['src/app.ts'],
+    summary: overrides.summary,
   });
 
-  it('可以实例化 PatchApplier', () => {
+  it('git 可用时应优先调用 git 策略并返回 strategy="git"', async () => {
     const applier = new PatchApplier();
-    expect(applier).toBeInstanceOf(PatchApplier);
+    const proposal = buildProposal({ id: 'patch_git_first' });
+    const gitStrategy = vi.fn<ApplyOptions['strategies']['git']>().mockResolvedValue({
+      success: true,
+      strategy: 'git',
+    });
+    const nativeStrategy = vi.fn<ApplyOptions['strategies']['native']>().mockResolvedValue({
+      success: true,
+      strategy: 'native',
+    });
+
+    const result = await (
+      applier as unknown as {
+        apply: (proposal: PatchProposal, options: ApplyOptions) => Promise<StrategyResult>;
+      }
+    ).apply(proposal, {
+      gitApplyAvailable: true,
+      fallbackToNative: true,
+      strategies: { git: gitStrategy, native: nativeStrategy },
+    });
+
+    expect(gitStrategy, 'git 策略应被优先执行').toHaveBeenCalledTimes(1);
+    expect(nativeStrategy, 'git 策略成功时不应触发 native').not.toHaveBeenCalled();
+    expect(result.strategy, '成功结果需明确标记使用的策略').toBe('git');
+    expect(result.success, 'git 策略成功时 overall 结果也应成功').toBe(true);
+  });
+
+  it('git 失败时应回退 native 并标记 usedFallback=true', async () => {
+    const applier = new PatchApplier();
+    const proposal = buildProposal({ id: 'patch_git_fallback' });
+    const gitStrategy = vi.fn<ApplyOptions['strategies']['git']>().mockResolvedValue({
+      success: false,
+      errorMessage: 'git apply rejected',
+      strategy: 'git',
+    });
+    const nativeStrategy = vi.fn<ApplyOptions['strategies']['native']>().mockResolvedValue({
+      success: true,
+      strategy: 'native',
+    });
+
+    const result = await (
+      applier as unknown as {
+        apply: (proposal: PatchProposal, options: ApplyOptions) => Promise<StrategyResult>;
+      }
+    ).apply(proposal, {
+      gitApplyAvailable: true,
+      fallbackToNative: true,
+      strategies: { git: gitStrategy, native: nativeStrategy },
+    });
+
+    expect(gitStrategy, 'git 策略应先执行即便失败').toHaveBeenCalledTimes(1);
+    expect(nativeStrategy, 'git 失败后必须执行 native 作为回退').toHaveBeenCalledTimes(1);
+    expect(result.success, '回退成功则整体结果仍应成功').toBe(true);
+    expect(result.strategy, '结果策略应指向 native').toBe('native');
+    expect(result.usedFallback, '触发回退时需标记 usedFallback').toBe(true);
+  });
+
+  it('目标文件为空时直接失败并返回清晰错误信息', async () => {
+    const applier = new PatchApplier();
+    const proposal = buildProposal({ id: 'patch_empty', targetFiles: [] });
+
+    const result = await applier.apply(proposal);
+
+    expect(result.success, '缺少目标文件时必须失败').toBe(false);
+    expect(result.errorMessage ?? '', '错误信息应提示目标文件为空').toMatch(
+      /目标文件|target file|空/
+    );
+  });
+
+  it('当 git 抛错且 native 也失败时需冒泡最终失败错误', async () => {
+    const applier = new PatchApplier();
+    const proposal = buildProposal({ id: 'patch_double_failure' });
+    const gitStrategy = vi
+      .fn<ApplyOptions['strategies']['git']>()
+      .mockRejectedValue(new Error('git apply exploded'));
+    const nativeStrategy = vi.fn<ApplyOptions['strategies']['native']>().mockResolvedValue({
+      success: false,
+      strategy: 'native',
+      errorMessage: 'native diff rejected',
+    });
+
+    const result = await (
+      applier as unknown as {
+        apply: (proposal: PatchProposal, options: ApplyOptions) => Promise<StrategyResult>;
+      }
+    ).apply(proposal, {
+      gitApplyAvailable: true,
+      fallbackToNative: true,
+      strategies: { git: gitStrategy, native: nativeStrategy },
+    });
+
+    expect(gitStrategy).toHaveBeenCalledTimes(1);
+    expect(nativeStrategy).toHaveBeenCalledTimes(1);
+    expect(result.success, '双策略都失败时应返回失败').toBe(false);
+    expect(result.errorMessage ?? '', '需包含来自回退失败的上下文').toMatch(
+      /native|失败|fallback/i
+    );
   });
 });

--- a/core/orchestrator/tests/resource-monitor.test.ts
+++ b/core/orchestrator/tests/resource-monitor.test.ts
@@ -1,13 +1,112 @@
-import { describe, expect, it } from 'vitest';
-import { ResourceMonitor } from '../resource-monitor';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ResourceSnapshot } from '../types';
 
-describe('resource-monitor', () => {
-  it('导出 ResourceMonitor 类', () => {
-    expect(typeof ResourceMonitor).toBe('function');
+type ShouldDownscaleResult = {
+  downscale: boolean;
+  reason?: string;
+  hysteresisActive?: boolean;
+};
+
+type ShouldDownscaleConfig = {
+  cpuThreshold?: number;
+  memoryThreshold?: number;
+  hysteresis?: number;
+  previousDecision?: {
+    downscale: boolean;
+    timestamp: number;
+  };
+};
+
+type ShouldDownscale = (
+  snapshot: ResourceSnapshot,
+  config: ShouldDownscaleConfig
+) => ShouldDownscaleResult;
+
+const loadShouldDownscale = async (): Promise<ShouldDownscale | undefined> => {
+  const resourceModule = await import('../resource-monitor');
+  return resourceModule.shouldDownscale as ShouldDownscale | undefined;
+};
+
+describe('ResourceMonitor 阈值与滞回契约', () => {
+  afterEach(() => {
+    vi.resetModules();
   });
 
-  it('可以实例化 ResourceMonitor', () => {
-    const monitor = new ResourceMonitor();
-    expect(monitor).toBeInstanceOf(ResourceMonitor);
+  it('导出 shouldDownscale(snapshot, cfg) 纯函数以便独立测试', async () => {
+    const shouldDownscale = await loadShouldDownscale();
+    expect(shouldDownscale, 'ResourceMonitor 模块需要导出 shouldDownscale 用于策略判定').toBeTypeOf(
+      'function'
+    );
+  });
+
+  it('CPU 使用率超阈值时应提示 downscale=true 并给出 CPU 理由', async () => {
+    const shouldDownscale = await loadShouldDownscale();
+    expect(shouldDownscale, '缺少 shouldDownscale 实现导致无法断言阈值逻辑').toBeTypeOf('function');
+    if (typeof shouldDownscale !== 'function') {
+      return;
+    }
+
+    const snapshot: ResourceSnapshot = {
+      cpuUsage: 0.9,
+      memoryUsage: 256,
+      timestamp: Date.now(),
+    };
+    const result = shouldDownscale(snapshot, { cpuThreshold: 0.85 });
+
+    expect(result.downscale, 'CPU 超过 85% 时应立即降级').toBe(true);
+    expect(result.reason ?? '', '返回的理由应点明 CPU 限制').toMatch(/CPU|cpu|处理器/);
+  });
+
+  it('内存超标同样触发降级，并保留原因字段', async () => {
+    const shouldDownscale = await loadShouldDownscale();
+    expect(shouldDownscale, 'shouldDownscale 未达成导出契约').toBeTypeOf('function');
+    if (typeof shouldDownscale !== 'function') {
+      return;
+    }
+
+    const snapshot: ResourceSnapshot = {
+      cpuUsage: 0.5,
+      memoryUsage: 1024,
+      timestamp: Date.now(),
+    };
+    const result = shouldDownscale(snapshot, { memoryThreshold: 512 });
+
+    expect(result.downscale, '内存超过阈值时必须降级').toBe(true);
+    expect(result.reason ?? '', '理由需说明内存触发降级').toMatch(/memory|内存|RAM/i);
+  });
+
+  it('滞回：降级后需 cpuUsage 低于阈值-hysteresis 方可恢复', async () => {
+    const shouldDownscale = await loadShouldDownscale();
+    expect(shouldDownscale, '缺失 shouldDownscale 将无法覆盖滞回逻辑').toBeTypeOf('function');
+    if (typeof shouldDownscale !== 'function') {
+      return;
+    }
+
+    const config: ShouldDownscaleConfig = {
+      cpuThreshold: 0.85,
+      hysteresis: 0.1,
+      previousDecision: {
+        downscale: true,
+        timestamp: Date.now() - 1000,
+      },
+    };
+
+    const snapshotStillHigh: ResourceSnapshot = {
+      cpuUsage: 0.8,
+      memoryUsage: 128,
+      timestamp: Date.now(),
+    };
+    const stayResult = shouldDownscale(snapshotStillHigh, config);
+    expect(stayResult.downscale, 'CPU 仍高于 0.75 时应保持降级').toBe(true);
+    expect(stayResult.hysteresisActive ?? false, '滞回持续时应明确告知正在生效').toBe(true);
+
+    const snapshotRecovered: ResourceSnapshot = {
+      cpuUsage: 0.7,
+      memoryUsage: 128,
+      timestamp: Date.now() + 500,
+    };
+    const recoverResult = shouldDownscale(snapshotRecovered, config);
+    expect(recoverResult.downscale, 'CPU 降至 0.75 以下时应允许恢复').toBe(false);
+    expect(recoverResult.hysteresisActive ?? false, '恢复后滞回标记应关闭').toBe(false);
   });
 });

--- a/core/orchestrator/tests/sww-coordinator.test.ts
+++ b/core/orchestrator/tests/sww-coordinator.test.ts
@@ -1,13 +1,128 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { SWWCoordinator } from '../sww-coordinator';
+import type { Patch } from '../types';
 
-describe('sww-coordinator', () => {
-  it('导出 SWWCoordinator 类', () => {
-    expect(typeof SWWCoordinator).toBe('function');
+describe('SWWCoordinator 单写窗口协调', () => {
+  let coordinator: SWWCoordinator;
+  let patchCounter = 0;
+
+  const buildPatch = (overrides: Partial<Patch> = {}): Patch => {
+    patchCounter += 1;
+    return {
+      id: overrides.id ?? `patch_${patchCounter}`,
+      taskId: overrides.taskId ?? `t-task-${patchCounter}`,
+      sequence: overrides.sequence ?? patchCounter,
+      filePath: overrides.filePath ?? `/tmp/demo-${patchCounter}.diff`,
+      targetFiles: overrides.targetFiles ?? [`/tmp/demo-${patchCounter}.diff`],
+      status: overrides.status ?? 'pending',
+      createdAt: overrides.createdAt ?? '2025-01-01T00:00:00.000Z',
+      appliedAt: overrides.appliedAt,
+      error: overrides.error,
+    };
+  };
+
+  beforeEach(() => {
+    coordinator = new SWWCoordinator();
+    patchCounter = 0;
   });
 
-  it('可以实例化 SWWCoordinator', () => {
-    const coordinator = new SWWCoordinator();
-    expect(coordinator).toBeInstanceOf(SWWCoordinator);
+  it('非当前写者抢占窗口时抛错 "Single writer window is busy"', async () => {
+    (coordinator as unknown as { currentWriter: string }).currentWriter = 't-task-keeper';
+    const competingPatch = buildPatch({ id: 'patch_conflict', taskId: 't-task-other' });
+
+    await expect(coordinator.applyPatch(competingPatch)).rejects.toThrowError(
+      /Single writer window is busy/
+    );
+  });
+
+  it('preCheck 失败会触发 patch_failed 事件并将补丁标记为 failed', async () => {
+    const recordedFailed: Array<{ event: string; errorMessage?: string; patch: Patch }> = [];
+    coordinator.on('patch_failed', (payload) => {
+      recordedFailed.push(payload);
+    });
+
+    const invalidPatch = buildPatch({
+      id: 'patch_precheck_failed',
+      taskId: 't-task-precheck',
+      targetFiles: [],
+    });
+
+    coordinator.enqueuePatch(invalidPatch);
+    await coordinator.processQueue();
+
+    expect(recordedFailed.length, '应捕获到一次 patch_failed 事件').toBe(1);
+    const failedEvent = recordedFailed[0];
+    expect(failedEvent.event, '事件类型应为 patch_failed').toBe('patch_failed');
+    expect(failedEvent.patch.status, '补丁状态应更新为 failed').toBe('failed');
+    expect(failedEvent.errorMessage ?? '', '失败消息需提示 targetFiles 问题').toContain(
+      'targetFiles'
+    );
+    expect(failedEvent.patch.error ?? '', '事件载荷应携带错误详情').toContain('targetFiles');
+  });
+
+  it('补丁队列严格串行，后续事件晚于先前补丁完成', async () => {
+    const timeline: string[] = [];
+    coordinator.on('patch_applied', (payload) => {
+      timeline.push(`applied:${payload.patch.id}`);
+    });
+    coordinator.on('patch_failed', (payload) => {
+      timeline.push(`failed:${payload.patch.id}`);
+    });
+
+    const firstPatch = buildPatch({ id: 'patch_first', taskId: 't-task-first', sequence: 1 });
+    const secondPatch = buildPatch({ id: 'patch_second', taskId: 't-task-second', sequence: 2 });
+
+    coordinator.enqueuePatch(firstPatch);
+    coordinator.enqueuePatch(secondPatch);
+    await coordinator.processQueue();
+
+    expect(timeline, '事件顺序应严格按照队列顺序串行').toEqual([
+      'applied:patch_first',
+      'applied:patch_second',
+    ]);
+    expect(
+      coordinator.events.map((evt) => evt.patch.id),
+      '事件历史中的补丁顺序应与时间线一致'
+    ).toEqual(['patch_first', 'patch_second']);
+    expect(
+      coordinator.events.every((evt) => evt.patch.status === 'applied'),
+      '串行执行完成后事件载荷中的补丁应处于 applied 状态'
+    ).toBe(true);
+  });
+
+  it('回滚路径：第二个补丁失败时不影响已完成的第一个补丁', async () => {
+    const timeline: string[] = [];
+    coordinator.on('patch_applied', (payload) => {
+      timeline.push(`applied:${payload.patch.id}`);
+    });
+    coordinator.on('patch_failed', (payload) => {
+      timeline.push(`failed:${payload.patch.id}`);
+    });
+
+    const successfulPatch = buildPatch({
+      id: 'patch_success',
+      taskId: 't-task-success',
+      sequence: 1,
+    });
+    const rollbackPatch = buildPatch({
+      id: 'patch_rollback',
+      taskId: 't-task-rollback',
+      sequence: 2,
+      targetFiles: [],
+    });
+
+    coordinator.enqueuePatch(successfulPatch);
+    coordinator.enqueuePatch(rollbackPatch);
+    await coordinator.processQueue();
+
+    expect(timeline, '应先成功第一个补丁，再记录第二个失败').toEqual([
+      'applied:patch_success',
+      'failed:patch_rollback',
+    ]);
+    const history = coordinator.events;
+    expect(history[0]?.patch.status, '首个补丁状态必须保持 applied').toBe('applied');
+    expect(history[0]?.patch.error, '首个补丁不应残留错误信息').toBeUndefined();
+    expect(history[1]?.event, '第二个补丁需记录失败事件').toBe('patch_failed');
+    expect(history[1]?.patch.error ?? '', '失败补丁应记录具体错误').toContain('targetFiles');
   });
 });


### PR DESCRIPTION
本PR仅新增三处红测以驱动实现：\n\n- T025：SWW 单写窗口——冲突/预检失败/严格串行/失败回滚不影响已完成补丁\n- T026：ResourceMonitor 契约——shouldDownscale + 滞回边界（红测）\n- T027：PatchApplier 策略——优选 git/回退 native/错误传播（红测）\n\n说明：\n- 受 Vitest 排除规则影响，按文件路径运行仍被 exclude（见 package.json exclude: core/orchestrator/tests/**）。因此当前仅提交用例，执行需后续调整 vitest 配置或提供临时 include。\n- 未改动实现代码；仅 3 个测试文件。\n\n请先合入以解锁后续实现任务（T015/T016/T017/T018 等）。